### PR TITLE
Use new cash domain for BCH Explorer

### DIFF
--- a/src/pages/recommended.mdx
+++ b/src/pages/recommended.mdx
@@ -159,6 +159,7 @@ A compilation of suggested accounts [here](https://twitter.com/btcfork/status/16
 - [MiniSatoshi](https://twitter.com/_minisatoshi)
 - [Korben Dallas Multipass](https://twitter.com/KDM2718)
 - [NeonDaThal](https://twitter.com/NeonDaThal)
+- [BCH Explorer](https://x.com/bchexplorer/)
 
 There are of course many other BCH Twitter users who can be found by following discussion from some of the suggested accounts.
 

--- a/src/pages/recommended.mdx
+++ b/src/pages/recommended.mdx
@@ -232,7 +232,7 @@ There are of course many other BCH Twitter users who can be found by following d
 
 ### Block Explorers
 
-- [Melroy's Block Explorer](https://explorer.melroy.org/)
+- [BCH Explorer](https://bchexplorer.cash/): Bitcoin Cash explorer by Melroy van den Berg.
 - [BCH.Loping Explorer](https://bch.loping.net/)
 - [Cashflow.dev](https://cashflow.dev/): A unique visual blockchain explorer.
 - [Ninja BCH Block Explorer](https://explorer.bch.ninja/)

--- a/src/pages/stats.mdx
+++ b/src/pages/stats.mdx
@@ -54,7 +54,7 @@ For this website! Started tracking October 2021 with Google analytics.
 
 ## On Chain BCH Data
 
-- [Melroy's Block Explorer](https://explorer.melroy.org/)
+- [BCH Explorer](https://bchexplorer.cash/) (by Melroy van den Berg)
 - [Ninja BCH Block Explorer](https://explorer.bch.ninja/)
 - [Jett Scythe's BCH Grafana Dashboard](https://metrics.jettscythe.xyz/public-dashboards/0c3823b0103d4fa8a90d03f3f715742f?orgId=1&refresh=5s&from=now-1h&to=now)
 


### PR DESCRIPTION
I registered a dedicated URL for the explorer to make it more official now: https://bchexplorer.cash 


Also added to the X link.